### PR TITLE
Drop upper bound on wl-pprint-text

### DIFF
--- a/hsx-jmacro.cabal
+++ b/hsx-jmacro.cabal
@@ -29,5 +29,5 @@ Library
                      hsp            >= 0.9    && < 0.11,
                      jmacro         >= 0.6    && < 0.7,
                      mtl            >= 2.0    && < 2.3,
-                     wl-pprint-text == 1.1.*,
+                     wl-pprint-text >= 1.1,
                      text           >= 0.11 && < 1.3


### PR DESCRIPTION
hsx-jmacro builds with wl-pprint-text 1.2.0.0